### PR TITLE
Display actual content in failure message

### DIFF
--- a/lib/capybara_minitest_spec/matcher.rb
+++ b/lib/capybara_minitest_spec/matcher.rb
@@ -30,13 +30,18 @@ module CapybaraMiniTestSpec
 
     # Compose failure message.
     # E.g. Matcher failed: has_css?("expected", {:count => 1})
-    def self.failure_message(assertion_method, matcher_name, *args)
+    def self.failure_message(page, assertion_method, matcher_name, *args)
       if assertion_method == 'assert'
-        message = "Matcher failed: "
+        message = "Expected match: "
+        delimiter = "\n"
       else
-        message = 'Matcher should have failed: '
+        message = "Expected no match: "
+        delimiter = "\n   "
       end
-      message += "#{matcher_name}(#{args.map(&:inspect).join(', ')})"
+      message << "#{matcher_name}(#{args.map(&:inspect).join(', ')})"
+      message << delimiter 
+      message << "Actual content: "
+      message << page.to_s
     end
 
     private
@@ -54,7 +59,7 @@ module CapybaraMiniTestSpec
       matcher = self
       assertion_method = name.positive? ? 'assert' : 'refute'
       MiniTest::Assertions.send :define_method, name.assertion do |page, *args|
-        message = matcher.class.failure_message(assertion_method, matcher.name.original, *args)
+        message = matcher.class.failure_message(page, assertion_method, matcher.name.original, *args)
         send(assertion_method, matcher.test(page, *args), message)
       end
     end

--- a/test/matcher_spec.rb
+++ b/test/matcher_spec.rb
@@ -33,13 +33,12 @@ describe CapybaraMiniTestSpec::Matcher do
   end
 
   it "#failure_message with 'assert' arg returns positive assertion failure message" do
-    message = CapybaraMiniTestSpec::Matcher.failure_message('assert', :has_css?, {:option => 1})
-    message.must_equal 'Matcher failed: has_css?({:option=>1})'
+    message = CapybaraMiniTestSpec::Matcher.failure_message('<h1>Test</h1>', 'assert', :has_css?, {:option => 1})
+    message.must_equal "Expected match: has_css?({:option=>1})\nActual content: <h1>Test</h1>"
   end
 
   it "#failure_message with 'refute' arg returns negative assertion failure message" do
-    message = CapybaraMiniTestSpec::Matcher.failure_message('refute', :has_css?, {:option => 1})
-    message.must_equal 'Matcher should have failed: has_css?({:option=>1})'
+    message = CapybaraMiniTestSpec::Matcher.failure_message('<h1>Test</h1>', 'refute', :has_css?, {:option => 1})
+    message.must_equal "Expected no match: has_css?({:option=>1})\n   Actual content: <h1>Test</h1>"
   end
-
 end


### PR DESCRIPTION
When doing BDD I find it very useful to see the actual content that failed to match along with the matcher itself. Did a basic implementation pretty much following the "Expected:" compared to "Actual:" pattern in the `must_equal` matcher.

How do you like it? Any suggestions for further improving it?

I was thinking of doing a pretty print for larger documents, but skipped it for the sake of simplicity.
