### PR TITLE
Require 'capybara/dsl' explicitly

### DIFF
--- a/spec/capybara_rspec_matchers.spec.rb
+++ b/spec/capybara_rspec_matchers.spec.rb
@@ -32,6 +32,7 @@ end
 # There is a capybara/spec/spec_helper, but the following lines seeem to be enough.
 # Also, capybara/spec/spec_helper requires rspec.
 require 'capybara/spec/test_app'
+require 'capybara/dsl'
 Capybara.default_selector = :xpath
 Capybara.app = TestApp
 


### PR DESCRIPTION
Needed since https://github.com/teamcapybara/capybara/commit/635671904345299bf6e351cc3e71c3fdfc836518

Otherwise tests execution fail:
```
$ ruby -Ilib -e 'Dir.glob "./spec/*.spec.rb", &method(:require)'
/builddir/build/BUILD/capybara_minitest_spec-1.0.5/usr/share/gems/gems/capybara_minitest_spec-1.0.5/spec/capybara_rspec_matchers.spec.rb:40:in `block in <top (required)>': uninitialized constant Capybara::DSL (NameError)
        from /usr/share/gems/gems/minitest-5.10.2/lib/minitest/spec.rb:83:in `class_eval'
        from /usr/share/gems/gems/minitest-5.10.2/lib/minitest/spec.rb:83:in `describe'
        from /builddir/build/BUILD/capybara_minitest_spec-1.0.5/usr/share/gems/gems/capybara_minitest_spec-1.0.5/spec/capybara_rspec_matchers.spec.rb:39:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from -e:1:in `glob'
        from -e:1:in `<main>'

```