### PR TITLE
Quiet syntax warning

### DIFF
--- a/lib/capybara_minitest_spec/test_name.rb
+++ b/lib/capybara_minitest_spec/test_name.rb
@@ -16,7 +16,7 @@ module CapybaraMiniTestSpec
   private
 
     def has
-      have.sub /^have/, 'has'
+      have.sub(/^have/, 'has')
     end
 
     def have


### PR DESCRIPTION
Warning was "test_name.rb:19: warning: ambiguous first argument; put parentheses or a space even after `/' operator"